### PR TITLE
Add project dev setup

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,9 @@
+name: mode-notebook-assets
+
+type: python
+
+up:
+  - python: 3.7.3
+  - pip:
+    - requirements.txt
+    # - path/to/other.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+plotly
+numpy
+matplotlib


### PR DESCRIPTION
It would be handy to have `dev.yml` set up for this project to support local development. In the future, we might consider occasionally replicating the requirements.txt file for Mode notebook's Python Edge.